### PR TITLE
Fix code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/server.js
+++ b/server.js
@@ -201,7 +201,13 @@ const app = express()
   // Middleware to serve any .yml files in USER_DATA_DIR with optional protection
   .get('/*.yml', protectConfig, (req, res) => {
     const ymlFile = req.path.split('/').pop();
-    res.sendFile(path.join(__dirname, process.env.USER_DATA_DIR || 'user-data', ymlFile));
+    const userDataDir = path.resolve(__dirname, process.env.USER_DATA_DIR || 'user-data');
+    const resolvedPath = path.resolve(userDataDir, ymlFile);
+    if (!resolvedPath.startsWith(userDataDir)) {
+      res.status(403).send('Forbidden');
+      return;
+    }
+    res.sendFile(resolvedPath);
   })
   // Serves up static files
   .use(express.static(path.join(__dirname, process.env.USER_DATA_DIR || 'user-data')))


### PR DESCRIPTION
Fixes [https://github.com/khulnasoft/shipyard/security/code-scanning/8](https://github.com/khulnasoft/shipyard/security/code-scanning/8)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. This can be achieved by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root directory. If the path is not within the root directory, we should return a 403 Forbidden response.

1. Normalize the `ymlFile` path using `path.resolve`.
2. Check if the resolved path starts with the root directory.
3. If the path is outside the root directory, return a 403 Forbidden response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
